### PR TITLE
Gradle 5 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
 apply plugin: 'com.gradle.plugin-publish'
-apply from: 'localPublish.gradle'
 
 group = 'com.cisco.gradle'
 version = '1.15'
@@ -11,6 +10,9 @@ ext {
     publishHomepage = 'https://github.com/awrichar/gradle-external-build'
 }
 
+apply from: 'localPublish.gradle'
+
+sourceCompatibility = '1.6'
 targetCompatibility = '1.6'
 
 buildscript {

--- a/src/main/groovy/com/cisco/gradle/externalbuild/ExternalBuildPlugin.groovy
+++ b/src/main/groovy/com/cisco/gradle/externalbuild/ExternalBuildPlugin.groovy
@@ -165,7 +165,7 @@ class ExternalBuildPlugin implements Plugin<Project> {
             File outputFile = build.outputFiles[binary]
 
             // Replace the normal create/link actions with a simple copy
-            task.deleteAllActions()
+            task.actions = []
             if (outputFile) {
                 task.source(outputFile)
                 task.doFirst {

--- a/src/main/groovy/com/cisco/gradle/externalbuild/internal/DefaultExternalNativeExecutableSpec.groovy
+++ b/src/main/groovy/com/cisco/gradle/externalbuild/internal/DefaultExternalNativeExecutableSpec.groovy
@@ -7,7 +7,6 @@ import com.cisco.gradle.externalbuild.context.BuildOutputContext
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Task
-import org.gradle.api.internal.ClosureBackedAction
 import org.gradle.internal.Actions
 import org.gradle.nativeplatform.internal.DefaultNativeExecutableSpec
 

--- a/src/main/groovy/com/cisco/gradle/externalbuild/internal/DefaultExternalNativeLibrarySpec.groovy
+++ b/src/main/groovy/com/cisco/gradle/externalbuild/internal/DefaultExternalNativeLibrarySpec.groovy
@@ -7,7 +7,6 @@ import com.cisco.gradle.externalbuild.context.BuildOutputContext
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Task
-import org.gradle.api.internal.ClosureBackedAction
 import org.gradle.internal.Actions
 import org.gradle.nativeplatform.internal.DefaultNativeLibrarySpec
 

--- a/src/main/java/com.cisco.gradle.externalbuild/internal/ClosureBackedAction.java
+++ b/src/main/java/com.cisco.gradle.externalbuild/internal/ClosureBackedAction.java
@@ -1,0 +1,50 @@
+/* This is a copy of
+ * https://github.com/spring-gradle-plugins/dependency-management-plugin/blob/master/src/main/java/io/spring/gradle/dependencymanagement/internal/dsl/ClosureBackedAction.java
+ */
+package com.cisco.gradle.externalbuild.internal;
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+
+/**
+ * An {@link Action} that's backed by a {@link Closure}.
+ *
+ * @param <T> the type handled by this action
+ * @author Andy Wilkinson
+ */
+class ClosureBackedAction<T> implements Action<T> {
+
+    private final Closure closure;
+
+    ClosureBackedAction(Closure closure) {
+        this.closure = closure;
+    }
+
+    @Override
+    public void execute(T delegate) {
+        this.closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+        this.closure.setDelegate(delegate);
+        if (this.closure.getMaximumNumberOfParameters() == 0) {
+            this.closure.call();
+        }
+        else {
+            this.closure.call(delegate);
+        }
+    }
+
+}


### PR DESCRIPTION
This commit adds Gradle 5 support.
org.gradle.api.internal.ClosureBackedAction has different path in Gradle 5, so it is easier to have local implementation for compatibility.